### PR TITLE
fix: duplicate

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -9,10 +9,6 @@ provider:
       Action:
         - "dynamodb:*"
       Resource: "arn:aws:dynamodb:${opt:region, self:provider.region}:*:table/go-graphql-users"
-    - Effect: "Allow"
-      Action:
-        - "dynamodb:*"
-      Resource: "arn:aws:dynamodb:${opt:region, self:provider.region}:*:table/go-graphql-users"
 
 package:
  exclude:


### PR DESCRIPTION
I found a duplicate setting.
```yml
    - Effect: "Allow"
      Action:
        - "dynamodb:*"
      Resource: "arn:aws:dynamodb:${opt:region, self:provider.region}:*:table/go-graphql-users"
```